### PR TITLE
refactor(translcude): get rid of parent property and test

### DIFF
--- a/dist/ng-component.js
+++ b/dist/ng-component.js
@@ -27,7 +27,7 @@ angular.module('ngComponent', [])
         return {
           pre: function() {
             if (cache.beforeReadyFn) {
-              cache.beforeReadyFn.apply(this, arguments);
+              cache.beforeReadyFn.apply(that, arguments);
             }
           },
 
@@ -41,11 +41,11 @@ angular.module('ngComponent', [])
                   var locals = [].slice.call(args);
                   locals.unshift(e);
 
-                  cb.apply(this, locals);
+                  cb.apply(that, locals);
 
-                }.bind(this));
-              }.bind(this));
-            }.bind(this));
+                });
+              });
+            });
 
 
             scope.$on('$destroy', function() {
@@ -55,20 +55,12 @@ angular.module('ngComponent', [])
             });
 
             if (cache.readyFn) {
-              cache.readyFn.apply(this, args);
+              cache.readyFn.apply(that, args);
             }
 
             if (cache._template) {
-              // var compiled = globe.$compile(cache._template)(scope);
               element.html(cache._template);
-              // element.replaceWith(compiled.html());
               globe.$compile(element.contents())(scope);
-            }
-
-            if (cache.observe) {
-              angular.forEach(cache.observe, function(cb, attr) {
-                attr.$observe.call(that, attr, cb);
-              });
             }
           }
         };
@@ -157,20 +149,6 @@ angular.module('ngComponent', [])
     this._cache.start = cb || function(){};
     return this;
   };
-
-  Component.prototype.parent = function(parent) {
-    if (parent) {
-      this.require = '^?'+ parent;
-    }
-    return this;
-  };
-
-  // Component.prototype.observe = function(attr, cb) {
-  //   if (attr && cb && typeof cb === 'function') {
-  //     this._cache.observe = this._cache.observe || {};
-  //     this._cache.observe[attr] = cb;
-  //   }
-  // };
 
   return {
     $get: ["$compile", function ($compile) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,8 +19,6 @@ if(validBumpTypes.indexOf(Bump) === -1) {
   throw new Error('Unrecognized bump "' + Bump + '".');
 }
 
-console.log('bump---------', Bump)
-
 var args = { bump: Bump };
 
 // Paths to all src files
@@ -82,11 +80,6 @@ gulp.task('travis', function(done) {
   sync('build', 'test:ci', done);
 });
 
-// generate docs from our comments
-// gulp.task('doc', function() {
-//
-// });
-
 gulp.task('bump-version', function(){
   return gulp.src(['./package.json', './bower.json'])
     .pipe(bump({type:args.bump })) //major|minor|patch|prerelease
@@ -110,11 +103,17 @@ gulp.task('build', ['clean'], function(done) {
   sync('lint', done);
 });
 
+gulp.task('del:change', function() {
+  return gulp.src('./CHANGELOG.md')
+    .pipe(vf(del));
+});
+
 gulp.task('release', function(done){
   return sync(
     'build',
     'lint',
     'bump-version',
+    'del:change',
     'changelog',
     done
   );

--- a/specs/providerSpec.js
+++ b/specs/providerSpec.js
@@ -62,12 +62,12 @@ describe('ngComponent', function(){
       });
     });
   });
-  
+
   describe('Directive options', function() {
     it('should be an object', function() {
       expect(testDirectiveObject).to.be.an('object');
     });
-    
+
     describe('ready method', function() {
       it('should have a ready method', function() {
         expect(testDirectiveObject.ready).to.be.a('function');
@@ -79,7 +79,7 @@ describe('ngComponent', function(){
         expect(obj).to.be.an('object');
       });
     });
-    
+
     describe('on method', function() {
       it('should have an on method', function() {
         expect(testDirectiveObject.on).to.be.a('function');
@@ -114,16 +114,7 @@ describe('ngComponent', function(){
         // expect(testDirectiveObject.scopeOptions({})).to.be.an('object');
       });
     });
-    
-    describe('parent', function() {
-      it('should have a parent method', function() {
-        expect(testDirectiveObject.parent).to.be.an('function');
-      });
-      it('should return an object', function() {
-        expect(testDirectiveObject.parent('parent')).to.be.an('object');
-      });
-    });
-     
+
      describe('set template', function() {
       it('should have a set template method', function() {
         expect(testDirectiveObject.setTemplate).to.be.an('function');

--- a/src/ng-component.js
+++ b/src/ng-component.js
@@ -27,7 +27,7 @@ angular.module('ngComponent', [])
         return {
           pre: function() {
             if (cache.beforeReadyFn) {
-              cache.beforeReadyFn.apply(this, arguments);
+              cache.beforeReadyFn.apply(that, arguments);
             }
           },
 
@@ -41,11 +41,11 @@ angular.module('ngComponent', [])
                   var locals = [].slice.call(args);
                   locals.unshift(e);
 
-                  cb.apply(this, locals);
+                  cb.apply(that, locals);
 
-                }.bind(this));
-              }.bind(this));
-            }.bind(this));
+                });
+              });
+            });
 
 
             scope.$on('$destroy', function() {
@@ -55,20 +55,12 @@ angular.module('ngComponent', [])
             });
 
             if (cache.readyFn) {
-              cache.readyFn.apply(this, args);
+              cache.readyFn.apply(that, args);
             }
 
             if (cache._template) {
-              // var compiled = globe.$compile(cache._template)(scope);
               element.html(cache._template);
-              // element.replaceWith(compiled.html());
               globe.$compile(element.contents())(scope);
-            }
-
-            if (cache.observe) {
-              angular.forEach(cache.observe, function(cb, attr) {
-                attr.$observe.call(that, attr, cb);
-              });
             }
           }
         };
@@ -157,20 +149,6 @@ angular.module('ngComponent', [])
     this._cache.start = cb || function(){};
     return this;
   };
-
-  Component.prototype.parent = function(parent) {
-    if (parent) {
-      this.require = '^?'+ parent;
-    }
-    return this;
-  };
-
-  // Component.prototype.observe = function(attr, cb) {
-  //   if (attr && cb && typeof cb === 'function') {
-  //     this._cache.observe = this._cache.observe || {};
-  //     this._cache.observe[attr] = cb;
-  //   }
-  // };
 
   return {
     $get: function ($compile) {


### PR DESCRIPTION
- Remove parent feature for now
- Remove tests
- remove `function.bind` soup and use `var that = this`
